### PR TITLE
Improve QGIS 4 / Qt6 compatibility and harden raster editing workflow

### DIFF
--- a/Serval/band_spin_boxes.py
+++ b/Serval/band_spin_boxes.py
@@ -17,8 +17,8 @@ class BandBox(QgsDoubleSpinBox):
         super(BandBox, self).__init__(parent=parent)
         self.setMinimumSize(QSize(50, 24))
         self.setMaximumSize(QSize(50, 24))
-        self.setAlignment(Qt.AlignLeft)
-        self.setButtonSymbols(QAbstractSpinBox.NoButtons)
+        self.setAlignment(Qt.AlignmentFlag.AlignLeft)
+        self.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
         self.setKeyboardTracking(False)
         self.setShowClearButton(False)
         self.setExpressionsEnabled(False)
@@ -26,7 +26,7 @@ class BandBox(QgsDoubleSpinBox):
 
     def keyPressEvent(self, event):
         super(BandBox, self).keyPressEvent(event)
-        if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
+        if event.key() in (Qt.Key.Key_Return,Qt.Key.Key_Enter):
             self.enter_hit.emit()
 
 
@@ -38,8 +38,8 @@ class BandBoxes(QWidget):
         super(BandBoxes, self).__init__(parent=parent)
         self.bands = bands if bands else [1]
         self.data_types = data_types if data_types else [6]
-        self.nodata_values = nodata_values
-        self.sbox = None
+        self.nodata_values = nodata_values if nodata_values is not None else [None] * len(self.bands)
+        self.sbox: dict[int, BandBox] = {}
         lout = QHBoxLayout()
         lout.setSpacing(1)
         self.setLayout(lout)
@@ -48,14 +48,14 @@ class BandBoxes(QWidget):
     def remove_spinboxes(self):
         for i in reversed(range(self.layout().count())):
             self.layout().itemAt(i).widget().deleteLater()
-        self.sbox = None
+        self.sbox = {}
 
     def create_spinboxes(self, bands, data_types, nodata_values):
         self.remove_spinboxes()
         self.sbox = dict()
         self.bands = bands
         self.data_types = data_types
-        self.nodata_values = nodata_values
+        self.nodata_values = nodata_values if nodata_values is not None else [None] * len(self.bands)
         for nr in self.bands:
             dt = self.data_types[nr - 1]
             self.sbox[nr] = BandBox()
@@ -71,9 +71,15 @@ class BandBoxes(QWidget):
             self.sbox[nr].setEnabled(enable)
 
     def set_values(self, values):
-        for nr in self.sbox:
-            new_val = self.nodata_values[nr - 1] if values[nr - 1] is None else values[nr - 1]
-            self.sbox[nr].setValue(new_val)
+        if not values:
+             return
+         
+        for nr, sbox in self.sbox.items():
+            incoming = values[nr - 1] if nr - 1 < len(values) else None
+            nodata = self.nodata_values[nr - 1] if nr - 1 < len(self.nodata_values) else None
+            new_val = nodata if incoming is None else incoming
+            if new_val is not None:
+                sbox.setValue(new_val)
 
     def get_values(self):
         values = []

--- a/Serval/docs/user_manual.md
+++ b/Serval/docs/user_manual.md
@@ -1,8 +1,17 @@
-# Serval
+# Serval — User Manual
 
-Serval is a QGIS plugin for raster editing. 
+Serval is a QGIS plugin for raster editing.
+
+Recent versions of the plugin include internal improvements focused on better stability and compatibility with newer QGIS and Qt releases.
+Raster editing workflows have been hardened by adding additional checks for active layers, geometry validity and NoData handling.  
+Spatial index caching has also been improved to work reliably with multiple vector layers during expression-based raster updates.
+
+Serval allows editing raster values directly in the map canvas, using constant values, NoData assignment or values derived from
+QGIS expressions and external spatial layers.
+
 It provides convenient tools for modifying (small) raster parts and is _not_ intended to process entire images - 
 use Raster Calculator for this.
+
 Users can select some portions of a raster and apply one of the following modifications to selected cells:
 * set a constant value (including NODATA),
 * apply a QGIS expression value,
@@ -15,6 +24,11 @@ Raster cell selection tools include:
 * loading selection from a vector map layer.
 
 Multi-band rasters are fully supported - users can modify each band separately, or as RGB in case of 3/4-bands rasters.
+
+Band value widgets are now recreated dynamically when the active raster or band configuration changes.  
+This improves reliability when switching between single-band and multi-band rasters,
+especially in projects where rasters with different data types or NoData
+definitions are edited within the same session.
 
 Probing raster tool and drawing tool (changing single cell value) are also available.
 
@@ -94,7 +108,7 @@ Please note that for RGB bands active, the expression builder is not available a
 
 ### Pencil tool
 
-![Pencil tool](../icons/draw.svg) activates pencil, or drawing tool, used for changing single cell values.
+![Pencil tool](../icons/draw.svg) activates pencil, or drawing tool, used for changin single cell values.
 
 ### Apply constant value
 
@@ -104,6 +118,10 @@ Please note that for RGB bands active, the expression builder is not available a
 ### Apply NoData
 
 ![Apply NoData value](../icons/apply_nodata_value.svg) Applies NoData value to selected cells.
+
+Band value widgets are now recreated dynamically when the active raster or band configuration changes.  
+This improves reliability when switching between single-band and multi-band rasters,
+especially in projects where rasters with different data types or NoData definitions are edited within the same session.
 
 If NoData is not defined or need to be changed, see [Changing raster NoData value](#change-raster-nodata-value).
 
@@ -147,7 +165,8 @@ If NoData is found in one of neighboring cells, it is ignored.
 
 ![Undo](../icons/undo.svg) and ![Redo](../icons/redo.svg) buttons are used for undo and redo last operations.
 Number of undo steps to keep in memory is configurable. Default value is 3.
-
+Undo/redo management has been internally refactored to better track changes per raster layer.
+This reduces the risk of inconsistent states when switching between different rasters during an editing session.
 
 ### Change raster NoData value 
 
@@ -167,6 +186,20 @@ They are available from _Serval_ of the central widget of QGIS Expression Builde
 
 **Note**: When using them for raster modification, make sure that any vector or mesh layer used in the expression have the same
 coordinate system as the raster.
+
+Expression helper functions have been updated to improve spatial indexing performance and stability when working with multiple vector layers.
+Nearest-feature and interpolation functions now include additional geometry validity checks and improved handling of empty query results.
+
+Typical use cases include:
+
+- nearest feature attribute lookup
+- interpolation along line geometries
+- averaging attribute values of intersecting features
+- mesh dataset sampling
+
+These functions enable advanced raster editing workflows driven by
+external spatial datasets.
+
 
 
 ### Function `interpolate_from_mesh`
@@ -226,3 +259,19 @@ Syntax:
 Arguments:
 
 * `vlayer_id` - linestring vector layer id - get it from _Map Layers_ group
+
+
+## Editing considerations
+
+- Raster editing modifies the source dataset directly.
+- Ensure proper backups before large editing operations.
+- Performance depends on raster size, provider type and system memory.
+- Expression-based editing may require spatial indexes on vector layers for optimal performance.
+
+## Stability and compatibility notes
+
+Recent internal updates focused on improving plugin reliability in modern
+QGIS environments (QGIS 3.3x and QGIS 4 development versions).
+These changes do not modify user workflows but provide safer raster editing
+operations, improved handling of temporary layers and more predictable
+results when using expression-based raster modification tools.

--- a/Serval/layer_select_dlg.py
+++ b/Serval/layer_select_dlg.py
@@ -9,13 +9,16 @@ from qgis.gui import QgsMapLayerComboBox
 
 class LayerSelectDialog(QDialog):
     def __init__(self, parent=None, title=""):
-        super(QDialog, self).__init__(parent)
+        super().__init__(parent)
 
         self.cbo = QgsMapLayerComboBox()
         self.cbo.setFilters(QgsMapLayerProxyModel.VectorLayer)
-        self.btns = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.btns = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
         self.btns.accepted.connect(self.accept)
         self.btns.rejected.connect(self.reject)
+        
         lout = QVBoxLayout()
         lout.addWidget(self.cbo)
         lout.addWidget(self.btns)

--- a/Serval/metadata.txt
+++ b/Serval/metadata.txt
@@ -1,9 +1,9 @@
 [general]
 name=Serval
 qgisMinimumVersion=3.10
-qgisMaximumVersion=3.99
+qgisMaximumVersion=4.99
 description=Raster editing tools
-version=3.32.0
+version=3.33.1
 author=Radoslaw Pasiok for Lutra Consulting Ltd.
 email=radek.pasiok@lutraconsulting.co.uk
 about=Raster editing tools - select and apply a modification to a chosen part of a raster. Features setting a constant value (also NoData), an expression (probing other rasters and interpolation on vector and mesh layers) and applying 3x3 low-pass filter. Multiband rasters are fully supported.
@@ -15,6 +15,11 @@ repository=https://github.com/lutraconsulting/serval
 # Uncomment the following line and add your changelog:
 
 changelog=
+        3.33.1 Improved Qt5/Qt6 and QGIS 3/4 compatibility.
+            * Improved robustness of raster selection tools and geometry handling.
+            * Refactored plugin state handling to avoid None-related runtime errors and static-analysis warnings.
+            * Hardened active raster lifecycle, undo/redo management, and NoData editing.
+            * Made multiband spinbox handling safer with better NoData/default value support.
         3.32.0 Added new raster type (Int8) to provider types
         3.10.5 Handle rasters with invalid path
         3.10.4 Fix for XYZ rasters and others non-GDAL providers

--- a/Serval/raster_handler.py
+++ b/Serval/raster_handler.py
@@ -32,8 +32,14 @@ class RasterHandler(QObject):
         self.bands_range = range(1, self.bands_nr + 1)
         self.active_bands = [1]
         self.project = QgsProject.instance()
-        self.crs_transform = None if self.project.crs() == self.layer.crs() else \
-            QgsCoordinateTransform(self.project.crs(), self.layer.crs(), self.project)
+        if self.project is not None and self.project.crs() != self.layer.crs():
+            self.crs_transform = QgsCoordinateTransform(
+                self.project.crs(),
+                self.layer.crs(),
+                self.project,
+            )
+        else:
+            self.crs_transform = None
         self.data_types = None
         self.nodata_values = None
         self.pixel_size_x = self.layer.rasterUnitsPerPixelX()
@@ -106,7 +112,10 @@ class RasterHandler(QObject):
         if self.logger:
             self.logger.debug(f"Selecting cells for geometries: {[g.asWkt() for g in geometries]}")
         if not geometries:
-            self.uc.bar_warn("Select some raster cells!")
+            if self.uc:
+                self.uc.bar_warn("Select some raster cells!")
+            elif self.logger:
+                self.logger.warning("Select some raster cells!")
             return
         self.selecting_geoms = dict()
         self.selected_cells = []
@@ -135,6 +144,21 @@ class RasterHandler(QObject):
             self.selecting_geoms[nr] = sgeom
             self.spatial_index.addFeature(nr, sgeom.boundingBox())
             geoms.append(sgeom)
+
+        if not geoms:
+            # Durante il disegno interattivo del poligono il map tool può inviare
+            # una geometria temporanea ancora non valida/chiusa. In quel caso
+            # evitiamo warning prematuri e usciamo in silenzio.
+            if transform:
+                 return
+
+            msg = "Selected geometry is invalid"
+            if self.uc:
+                self.uc.bar_warn(msg)
+            elif self.logger:
+                self.logger.warning(msg)
+            return
+
         self.total_geometry = QgsGeometry.unaryUnion(geoms)
         if self.logger:
             self.logger.debug(f"Total selecting geometry bbox: {self.total_geometry.boundingBox()}")
@@ -159,6 +183,7 @@ class RasterHandler(QObject):
                     if g.intersects(bbox):
                         self.selected_cells.append((row, col))
                         self.cell_centers[(row, col)] = (pt_x, pt_y)
+                        break
         if self.logger:
             self.logger.debug(f"Nr of cells selected: {len(self.selected_cells)}")
 
@@ -167,7 +192,25 @@ class RasterHandler(QObject):
         crs_str = self.layer.crs().authid().lower()
         fields_def = "field=row:int&field=col:int"
         self.cell_pts_layer = QgsVectorLayer(f"Point?crs={crs_str}&{fields_def}", "Temp raster cell points", "memory")
-        fields = self.cell_pts_layer.dataProvider().fields()
+        
+        cell_pts_layer = self.cell_pts_layer
+        if cell_pts_layer is None:
+            if self.logger:
+                self.logger.warning("Failed to create memory point layer")
+            return
+        
+        provider = cell_pts_layer.dataProvider()
+        
+        if provider is None:
+            if self.logger:
+                self.logger.warning("Failed to get memory layer data provider")
+            return
+        
+        if not self.cell_centers:
+            self.selected_cells_feats = {}
+            return
+
+        fields = provider.fields()
         feats = []
         for row_col, xy in self.cell_centers.items():
             row, col = row_col
@@ -177,10 +220,15 @@ class RasterHandler(QObject):
             feat["row"] = row
             feat["col"] = col
             feats.append(feat)
-        self.cell_pts_layer.dataProvider().addFeatures(feats)
-        self.selected_cells_feats = dict()  # {(row, cell): feat}
-        for feat in self.cell_pts_layer.getFeatures():
+            
+        provider.addFeatures(feats)
+
+        self.selected_cells_feats = {} # {(row, cell): feat}
+        features = cell_pts_layer.getFeatures()
+        feat = QgsFeature()
+        while features.nextFeature(feat):
             self.selected_cells_feats[(feat["row"], feat["col"])] = feat.id()
+            feat = QgsFeature()
 
     def write_block(self, const_values=None, low_pass_filter=False):
         """
@@ -200,9 +248,25 @@ class RasterHandler(QObject):
                 return None
         if self.logger:
             self.logger.debug("Calculating block origin coordinates...")
-        b_orig_x, b_orig_y = self.index_to_point(self.block_row_min, self.block_col_min)
-        cols = self.block_col_max - self.block_col_min + 1
-        rows = self.block_row_max - self.block_row_min + 1
+        
+        if (
+            self.block_row_min is None
+            or self.block_row_max is None
+            or self.block_col_min is None
+            or self.block_col_max is None
+        ):
+            if self.logger:
+                self.logger.warning("Block indices are not initialized")
+            return None
+        
+        row_min = self.block_row_min
+        row_max = self.block_row_max
+        col_min = self.block_col_min
+        col_max = self.block_col_max
+
+        b_orig_x, b_orig_y = self.index_to_point(row_min, col_min)
+        cols = col_max - col_min + 1
+        rows = row_max - row_min + 1
         b_end_x = b_orig_x + cols * self.pixel_size_x
         b_end_y = b_orig_y - rows * self.pixel_size_y
         block_bbox = QgsRectangle(b_orig_x, b_end_y, b_end_x, b_orig_y)
@@ -212,46 +276,97 @@ class RasterHandler(QObject):
         old_blocks = []
         new_blocks = []
         cell_values = dict()
+        
         if const_values is None and not low_pass_filter:
-            for feat in self.cell_pts_layer.getFeatures():
+            cell_pts_layer = self.cell_pts_layer
+            if cell_pts_layer is None:
+                if self.logger:
+                    self.logger.warning("Cell points layer is not available")
+                return None
+                
+            features = cell_pts_layer.getFeatures()
+            feat = QgsFeature()
+            while features.nextFeature(feat):
                 cell_values[feat.id()] = feat.attribute(self.exp_field_idx)
+                feat = QgsFeature()
+        
+        selected_cells = self.selected_cells
+        if not selected_cells:
+            if self.logger:
+                self.logger.warning("No selected cells available")
+            return None
+
+        selected_cells_feats = self.selected_cells_feats if const_values is None and not low_pass_filter else None
+        if const_values is None and not low_pass_filter and selected_cells_feats is None:
+            if self.logger:
+                self.logger.warning("Selected cell feature map is not available")
+            return None
+        
+        expression_selected_cells_feats = selected_cells_feats if selected_cells_feats is not None else {}
+
+        nodata_values = self.nodata_values
+        if nodata_values is None:
+            if self.logger:
+                self.logger.warning("NODATA values are not available")
+            return None
+
+        data_types = self.data_types
+        if data_types is None:
+            if self.logger:
+                self.logger.warning("Raster data types are not available")
+            return None
+
         for band_nr in self.active_bands:
             block = self.provider.block(band_nr, block_bbox, cols, rows)
             new_blocks.append(block)
             block_data = block.data().data()
-            old_block = QgsRasterBlock(self.data_types[band_nr - 1], cols, rows)
+            old_block = QgsRasterBlock(data_types[band_nr - 1], cols, rows)
             old_block.setData(block_data)
-            for abs_row, abs_col in self.selected_cells:
-                row = abs_row - self.block_row_min
-                col = abs_col - self.block_col_min
+
+            row_min = self.block_row_min
+            col_min = self.block_col_min
+            if row_min is None or col_min is None:
+                if self.logger:
+                    self.logger.warning("Block indices are not initialized")
+                return None
+
+            for abs_row, abs_col in selected_cells:
+                row = abs_row - row_min
+                col = abs_col - col_min
+
                 if const_values:
                     idx = band_nr - 1 if len(self.active_bands) > 1 else 0
                     new_val = const_values[idx]
+
                 elif low_pass_filter:
                     # the filter is applied for cells inside the block only
                     if block.height() < 3 or block.width() < 3:
                         # the selected block is too small for filtering -> keep the old value
                         new_val = None
                     else:
-                        new_val = low_pass_filtered(old_block, row, col, self.nodata_values[band_nr - 1])
+                        new_val = low_pass_filtered(old_block, row, col, nodata_values[band_nr - 1])
                 else:
                     # set the expression value
-                    feat_id = self.selected_cells_feats[(abs_row, abs_col)]
-                    if cell_values[feat_id] is not None:
-                        new_val = None if math.isnan(cell_values[feat_id]) or \
-                                      cell_values[feat_id] is None else cell_values[feat_id]
-                    else:
+                    feat_id = expression_selected_cells_feats[(abs_row, abs_col)]
+                    expr_val = cell_values.get(feat_id)
+                    if expr_val is None:
                         new_val = None
+                    else:
+                        new_val = None if math.isnan(expr_val) else expr_val
                 new_val = old_block.value(row, col) if new_val is None else new_val
                 set_res = block.setValue(row, col, new_val)
+
                 if self.logger:
                     self.logger.debug(f"Setting block value for band {band_nr}, row {row}, col: {col}: {set_res}")
+                         
             old_blocks.append(old_block)
-            band_res = self.provider.writeBlock(block, band_nr, self.block_col_min, self.block_row_min)
+            band_res = self.provider.writeBlock(block, band_nr, col_min, row_min)
+
             if self.logger:
                 self.logger.debug(f"Writing block for band {band_nr}: {band_res}")
+
         self.provider.setEditable(False)
-        change = RasterChange(self.active_bands, self.block_row_min, self.block_col_min, old_blocks, new_blocks)
+        change = RasterChange(self.active_bands, row_min, col_min, old_blocks, new_blocks)
         self.raster_changed.emit(change)
         return True
 
@@ -260,7 +375,7 @@ class RasterHandler(QObject):
         if self.logger:
             self.logger.debug(f"Writing blocks from undo")
         if not self.provider.isEditable():
-            res = self.provider.setEditable(True)
+            self.provider.setEditable(True)
         bands, row_min, col_min, blocks = data
         for band_nr in bands:
             idx = band_nr - 1 if len(bands) > 1 else 0

--- a/Serval/selection_tool.py
+++ b/Serval/selection_tool.py
@@ -28,14 +28,14 @@ class RasterCellSelectionMapTool(QgsMapTool):
         self.setCursor(QCursor(QPixmap(icon_path('select_tool.svg')), hotX=0, hotY=0))
         self.current_rubber_band = QgsRubberBand(self.iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)
         self.selected_rubber_band = QgsRubberBand(self.iface.mapCanvas(), QgsWkbTypes.PolygonGeometry)
-        self.current_points = None
-        self.selected_geometries = None
+        self.current_points = []
+        self.selected_geometries = []
         self.last_pos = None
         self.sel_line_width = 1
-        self.cur_sel_color = QColor(Qt.yellow)
-        self.cur_sel_fill_color = QColor(Qt.yellow)
-        self.sel_color = QColor(Qt.yellow)
-        self.sel_fill_color = QColor(Qt.yellow)
+        self.cur_sel_color = QColor(Qt.GlobalColor.yellow)
+        self.cur_sel_fill_color = QColor(Qt.GlobalColor.yellow)
+        self.sel_color = QColor(Qt.GlobalColor.yellow)
+        self.sel_fill_color = QColor(Qt.GlobalColor.yellow)
         self.prev_tool = None
         self.selection_mode = None
         self.logger = get_logger() if debug else None
@@ -48,11 +48,11 @@ class RasterCellSelectionMapTool(QgsMapTool):
         self.mode = mode
         self.sel_line_width = line_width
         self.geom_type = QgsWkbTypes.LineGeometry if mode == self.LINE_SELECTION else QgsWkbTypes.PolygonGeometry
-        self.cur_sel_color = Qt.yellow
-        self.cur_sel_fill_color = QColor(Qt.yellow)
+        self.cur_sel_color = QColor(Qt.GlobalColor.yellow)
+        self.cur_sel_fill_color = QColor(Qt.GlobalColor.yellow)
         self.cur_sel_fill_color.setAlpha(20)
-        self.sel_color = Qt.yellow
-        self.sel_fill_color = QColor(Qt.yellow)
+        self.sel_color = QColor(Qt.GlobalColor.yellow)
+        self.sel_fill_color = QColor(Qt.GlobalColor.yellow)
         self.sel_fill_color.setAlpha(20)
         return True
 
@@ -75,8 +75,8 @@ class RasterCellSelectionMapTool(QgsMapTool):
         self.current_rubber_reset()
         self.selected_rubber_reset()
         self.raster = None
-        self.current_points = None
-        self.selected_geometries = None
+        self.current_points = []
+        self.selected_geometries = []
 
     def selecting_finished(self):
         if self.logger:
@@ -106,17 +106,18 @@ class RasterCellSelectionMapTool(QgsMapTool):
     def clear_all_selections(self):
         self.current_selection_reset()
         self.selected_rubber_reset()
-        self.selected_geometries = None
+        self.selected_geometries = []
 
     def create_selecting_geometry(self, cur_position=None):
+        points = self.current_points if self.current_points is not None else []
         pt = [cur_position] if cur_position else []
         if self.geom_type == QgsWkbTypes.LineGeometry:
-            geom = QgsGeometry.fromPolylineXY(self.current_points + pt).buffer(self.sel_line_width / 2., 5)
+            geom = QgsGeometry.fromPolylineXY(points + pt).buffer(self.sel_line_width / 2.0, 5)
         else:
-            if len(self.current_points) < 2:
-                geom = QgsGeometry.fromPolylineXY(self.current_points + pt)
+            if len(points) < 2:
+                geom = QgsGeometry.fromPolylineXY(points + pt)
             else:
-                poly_pts = [self.current_points + pt]
+                poly_pts = [points + pt]
                 geom = QgsGeometry.fromPolygonXY(poly_pts)
         return geom
 
@@ -129,36 +130,45 @@ class RasterCellSelectionMapTool(QgsMapTool):
         if geom.isGeosValid():
             self.uc.clear_bar_messages()
         else:
+            # In modalità poligono i primi punti producono una geometria temporanea
+            # ancora non chiusa/non valida: evitiamo warning prematuri.
+            if self.geom_type == QgsWkbTypes.PolygonGeometry and len(self.current_points) <= 2:
+                return
             self.uc.bar_warn("Selected geometry is invalid")
 
     def selected_rubber_update(self):
         self.selected_rubber_reset()
-        if self.selected_geometries is None:
+        if not self.selected_geometries:
             return
         for geom in self.selected_geometries:
             self.selected_rubber_band.addGeometry(geom, None)
 
     def canvasMoveEvent(self, e):
-        if self.current_points is None:
+        if e is None or not self.current_points:
             return
-        self.current_rubber_update(self.toMapCoordinates(e.pos()))
-        self.last_pos = self.toMapCoordinates(e.pos())
+        map_pos = self.toMapCoordinates(e.pos())
+        self.current_rubber_update(map_pos)
+        self.last_pos = map_pos
 
     def keyPressEvent(self, e):
-        if e.key() == Qt.Key_Escape:
+        if e is None:
+            return
+        if e.key() == Qt.Key.Key_Escape:
             self.uc.bar_info("Tool aborted")
             self.selecting_finished()
-        elif e.key() == Qt.Key_Backspace:
+        elif e.key() == Qt.Key.Key_Backspace:
             if self.current_points:
                 self.current_points.pop()
             self.current_rubber_update(cur_position=self.last_pos if self.last_pos else None)
 
     def canvasReleaseEvent(self, e):
-        if e.button() == Qt.RightButton:
+        if e is None:
+            return
+        if e.button() == Qt.MouseButton.RightButton:
             modifiers = QApplication.keyboardModifiers()
-            if modifiers == Qt.ShiftModifier:
+            if modifiers == Qt.KeyboardModifier.ShiftModifier:
                 self.selection_mode = self.REMOVE_FROM_SELECTION
-            elif modifiers == Qt.ControlModifier:
+            elif modifiers == Qt.KeyboardModifier.ControlModifier:
                 self.selection_mode = self.ADD_TO_SELECTION
             else:
                 self.selection_mode = self.NEW_SELECTION
@@ -166,20 +176,17 @@ class RasterCellSelectionMapTool(QgsMapTool):
                 self.logger.debug(f"Right mouse button in mode: {self.selection_mode}")
             self.update_selection()
             return
-        if e.button() != Qt.LeftButton:
+        if e.button() != Qt.MouseButton.LeftButton:
             return
 
         cur_pos = self.toMapCoordinates(e.pos())
-        if self.current_points is None:
-            self.current_points = [cur_pos]
-        else:
-            self.current_points.append(cur_pos)
+        self.current_points.append(cur_pos)
         self.current_rubber_update(cur_position=cur_pos)
 
     def update_selection(self):
         if self.logger:
             self.logger.debug(f"Selection tool points: {[str(pt) for pt in self.current_points]}")
-        if self.current_points is None:
+        if not self.current_points:
             return
 
         new_geom = self.create_selecting_geometry()

--- a/Serval/serval.py
+++ b/Serval/serval.py
@@ -93,8 +93,8 @@ class Serval(object):
         self.crs_transform = None
         self.all_touched = None
         self.selection_mode = None
-        self.spatial_index_time = dict()  # {layer_id: creation time}
-        self.spatial_index = dict()  # {layer_id: spatial index}
+        self.spatial_index_time = {}  # {layer_id: creation time}
+        self.spatial_index = {}       # {layer_id: QgsSpatialIndex}
         self.selection_layers_count = 1
         self.debug = DEBUG
         self.logger = get_logger() if self.debug else None
@@ -124,7 +124,8 @@ class Serval(object):
         self.map_tool_btn = dict()  # {map tool: button activating the tool}
 
         self.iface.currentLayerChanged.connect(self.set_active_raster)
-        self.project.layersAdded.connect(self.set_active_raster)
+        if self.project is not None:
+            self.project.layersAdded.connect(self.set_active_raster)
         self.canvas.mapToolSet.connect(self.check_active_tool)
 
         self.register_exp_functions()
@@ -183,7 +184,7 @@ class Serval(object):
         self.map_tool_btn[self.probe_tool] = self.probe_btn
 
         self.color_btn = QgsColorButton()
-        self.color_btn.setColor(Qt.gray)
+        self.color_btn.setColor(QColor(Qt.GlobalColor.gray))
         self.color_btn.setMinimumSize(QSize(40, 24))
         self.color_btn.setMaximumSize(QSize(40, 24))
         self.toolbar.addWidget(self.color_btn)
@@ -362,7 +363,7 @@ class Serval(object):
         return action
 
     def unload(self):
-        self.changes = None
+        self.changes.clear()
         if self.selection_tool:
             self.selection_tool.reset()
         if self.spin_boxes is not None:
@@ -424,36 +425,69 @@ class Serval(object):
         if not self.selection_tool.selected_geometries:
             self.uc.bar_warn("No selection for raster layer. Select some cells and retry...")
             return
-        self.handler.select(self.selection_tool.selected_geometries, all_touched_cells=self.all_touched)
-        self.handler.create_cell_pts_layer()
-        if self.handler.cell_pts_layer.featureCount() == 0:
+        handler = self.handler
+        if handler is None:
+            if self.logger:
+                self.logger.warning("Raster handler is not available")
+            return
+        all_touched = bool(self.all_touched)
+        handler.select(self.selection_tool.selected_geometries, all_touched_cells=all_touched)
+        handler.create_cell_pts_layer()
+
+        cell_pts_layer = handler.cell_pts_layer
+        if cell_pts_layer is None or cell_pts_layer.featureCount() == 0:
             self.uc.bar_warn("No selection for raster layer. Select some cells and retry...")
             return
-        self.exp_dlg = QgsExpressionBuilderDialog(self.handler.cell_pts_layer)
+        self.exp_dlg = QgsExpressionBuilderDialog(cell_pts_layer)
         self.exp_builder = self.exp_dlg.expressionBuilder()
         self.exp_dlg.accepted.connect(self.apply_exp_value)
         self.exp_dlg.show()
 
     def apply_exp_value(self):
-        if not self.exp_dlg.expressionText() or not self.exp_builder.isExpressionValid():
+        exp_dlg = self.exp_dlg
+        exp_builder = self.exp_builder
+        handler = self.handler
+        raster = self.raster
+
+        if exp_dlg is None or exp_builder is None or handler is None or raster is None:
+            if self.logger:
+                self.logger.warning("Expression dialog/builder, raster handler, or raster layer is not available")
             return
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        exp = self.exp_dlg.expressionText()
-        idx = self.handler.cell_pts_layer.addExpressionField(exp, QgsField('exp_val', QVariant.Double))
-        self.handler.exp_field_idx = idx
-        self.handler.write_block()
-        QApplication.restoreOverrideCursor()
-        self.raster.triggerRepaint()
+
+        if not exp_dlg.expressionText() or not exp_builder.isExpressionValid():
+            return
+        
+        cell_pts_layer = handler.cell_pts_layer
+        if cell_pts_layer is None:
+            if self.logger:
+                self.logger.warning("Cell points layer is not available")
+            return
+
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            exp = exp_dlg.expressionText()
+            idx = cell_pts_layer.addExpressionField(exp, QgsField('exp_val', QVariant.Double))
+            handler.exp_field_idx = idx
+            handler.write_block()
+        finally:
+            QApplication.restoreOverrideCursor()
+
+        raster.triggerRepaint()
 
     def activate_drawing(self):
         self.mode = 'draw'
         self.canvas.setMapTool(self.draw_tool)
 
     def get_cur_line_width(self):
+        raster = self.raster
+        if raster is None:
+            if self.logger:
+                self.logger.warning("Active raster layer is not available")
+            return self.line_width_sbox.value()
         width_coef = {
-            "map units": 1.,
-            "pixel width": self.raster.rasterUnitsPerPixelX(),
-            "pixel height": self.raster.rasterUnitsPerPixelY(),
+            "map units": 1.0,
+            "pixel width": raster.rasterUnitsPerPixelX(),
+            "pixel height": raster.rasterUnitsPerPixelY(),
             "hairline": 0.000001,
         }
         return self.line_width_sbox.value() * width_coef[self.width_unit_cbo.currentText()]
@@ -483,45 +517,84 @@ class Serval(object):
             pass
 
     def apply_values(self, new_values):
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        self.handler.select(self.selection_tool.selected_geometries, all_touched_cells=self.all_touched)
-        self.handler.write_block(new_values)
-        QApplication.restoreOverrideCursor()
-        self.raster.triggerRepaint()
+        handler = self.handler
+        raster = self.raster
+        if handler is None or raster is None:
+            if self.logger:
+                self.logger.warning("Raster handler or active raster layer is not available")
+            return
+        all_touched = bool(self.all_touched)
+        
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            handler.select(self.selection_tool.selected_geometries, all_touched_cells=all_touched)
+            handler.write_block(new_values)
+        finally:
+            QApplication.restoreOverrideCursor()
+        raster.triggerRepaint()
 
     def apply_values_single_cell(self, new_vals):
         """Create single cell selection and apply the new values."""
+        handler = self.handler
+        raster = self.raster
         cp = self.last_point
+        if handler is None or raster is None:
+            if self.logger:
+                self.logger.warning("Raster handler or active raster layer is not available")
+            return
+
         if self.logger:
             self.logger.debug(f"Changing single cell for pt {cp}")
-        col, row = self.handler.point_to_index([cp.x(), cp.y()])
-        px, py = self.handler.index_to_point(row, col, upper_left=False)
+        col, row = handler.point_to_index([cp.x(), cp.y()])
+        px, py = handler.index_to_point(row, col, upper_left=False)
         d = 0.001
         bbox = QgsRectangle(px - d, py - d, px + d, py + d)
         if self.logger:
             self.logger.debug(f"Changing single cell in {bbox}")
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        self.handler.select([QgsGeometry.fromRect(bbox)], all_touched_cells=False, transform=False)
-        self.handler.write_block(new_vals)
-        QApplication.restoreOverrideCursor()
-        self.raster.triggerRepaint()
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            handler.select([QgsGeometry.fromRect(bbox)], all_touched_cells=False, transform=False)
+            handler.write_block(new_vals)
+        finally:        
+            QApplication.restoreOverrideCursor()
+        raster.triggerRepaint()
 
     def apply_spin_box_values(self):
         if not self.selection_tool.selected_geometries:
             return
-        self.apply_values(self.spin_boxes.get_values())
+        spin_boxes = self.spin_boxes
+        if spin_boxes is None:
+            if self.logger:
+                self.logger.warning("Band spin boxes are not available")
+            return
+        self.apply_values(spin_boxes.get_values())
 
     def apply_nodata_value(self):
         if not self.selection_tool.selected_geometries:
             return
-        self.apply_values(self.handler.nodata_values)
+        handler = self.handler
+        if handler is None:
+            if self.logger:
+                self.logger.warning("Raster handler is not available")
+            return
+        self.apply_values(handler.nodata_values)
 
     def apply_low_pass_filter(self):
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        self.handler.select(self.selection_tool.selected_geometries, all_touched_cells=self.all_touched)
-        self.handler.write_block(low_pass_filter=True)
-        QApplication.restoreOverrideCursor()
-        self.raster.triggerRepaint()
+        handler = self.handler
+        raster = self.raster
+        if handler is None or raster is None:
+            if self.logger:
+                self.logger.warning("Raster handler or active raster layer in not available")
+            return
+        all_touched = bool(self.all_touched)
+
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            handler.select(self.selection_tool.selected_geometries, all_touched_cells=all_touched)
+            handler.write_block(low_pass_filter=True)
+        finally:
+            QApplication.restoreOverrideCursor()
+        raster.triggerRepaint()
 
     def clear_selection(self):
         if self.selection_tool:
@@ -529,11 +602,20 @@ class Serval(object):
 
     def selection_from_layer(self):
         """Create a new selection from layer."""
-        self.selection_tool.init_tool(self.raster, mode=self.POLYGON_SELECTION, line_width=self.get_cur_line_width())
+        raster = self.raster
+        if raster is None:
+            if self.logger:
+                self.logger.warning("Active raster layer is not available")
+            return
+        self.selection_tool.init_tool(raster, mode=self.POLYGON_SELECTION, line_width=self.get_cur_line_width())
         dlg = LayerSelectDialog()
-        if not dlg.exec_():
+        if not dlg.exec():
             return
         cur_layer = dlg.cbo.currentLayer()
+        if cur_layer is None:
+            if self.logger:
+                self.logger.warning("No layer selected in layer selection dialog")
+            return
         if not cur_layer.type() == QgsMapLayerType.VectorLayer:
             return
         self.selection_tool.selection_from_layer(cur_layer)
@@ -541,21 +623,32 @@ class Serval(object):
     def selection_to_layer(self):
         """Create a memory layer from current selection"""
         geoms = self.selection_tool.selected_geometries
-        if geoms is None or not self.raster:
+        raster = self.raster
+        project = self.project        
+        
+        if geoms is None or raster is None or project is None:
+            if self.logger:
+                self.logger.warning("Selection, raster, or project is not available")
             return
-        crs_str = self.raster.crs().toProj()
+        crs_str = raster.crs().toProj()
         nr = self.selection_layers_count
         self.selection_layers_count += 1
+        
         mlayer = QgsVectorLayer(f"Polygon?crs={crs_str}&field=fid:int", f"Raster selection {nr}", "memory")
-        fields = mlayer.dataProvider().fields()
+        provider = mlayer.dataProvider()
+        if provider is None:
+            if self.logger:
+                self.logger.warning("Memory layer data provider is not available")
+            return        
+        fields = provider.fields()        
         features = []
         for i, geom in enumerate(geoms):
             feat = QgsFeature(fields)
             feat["fid"] = i + 1
             feat.setGeometry(geom)
             features.append(feat)
-        mlayer.dataProvider().addFeatures(features)
-        self.project.addMapLayer(mlayer)
+        provider.addFeatures(features)
+        project.addMapLayer(mlayer)
 
     def toggle_all_touched(self):
         """Toggle selection mode."""
@@ -563,8 +656,18 @@ class Serval(object):
         self.all_touched = self.toggle_all_touched_btn.isChecked()
 
     def point_clicked(self, point=None, button=None):
-        if self.raster is None:
+        raster = self.raster
+        handler = self.handler
+        spin_boxes = self.spin_boxes
+        rbounds = self.rbounds
+        
+        if raster is None:
             self.uc.bar_warn("Choose a raster to work with...", dur=3)
+            return
+
+        if handler is None or spin_boxes is None or rbounds is None:
+            if self.logger:
+                self.logger.warning("Raster handler, band spin boxes, or raster bounds are not available")
             return
 
         if self.logger:
@@ -589,53 +692,71 @@ class Serval(object):
             self.logger.debug(f"Clicked point in raster CRS: {ptxy_in_src_crs}")
         self.last_point = ptxy_in_src_crs
 
-        ident_vals = self.handler.provider.identify(ptxy_in_src_crs, QgsRaster.IdentifyFormatValue).results()
-        cur_vals = list(ident_vals.values())
-
         # check if the point is within active raster extent
-        if not self.rbounds[0] <= ptxy_in_src_crs.x() <= self.rbounds[2]:
+        if not rbounds[0] <= ptxy_in_src_crs.x() <= rbounds[2]:
             self.uc.bar_info("Out of x bounds", dur=3)
             return
-        if not self.rbounds[1] <= ptxy_in_src_crs.y() <= self.rbounds[3]:
+        if not rbounds[1] <= ptxy_in_src_crs.y() <= rbounds[3]:
             self.uc.bar_info("Out of y bounds", dur=3)
             return
+        
+        ident_vals = handler.provider.identify(ptxy_in_src_crs, QgsRaster.IdentifyFormatValue).results()
+        cur_vals = list(ident_vals.values())
 
         if self.mode == 'draw':
-            new_vals = self.spin_boxes.get_values()
+            new_vals = spin_boxes.get_values()
             if self.logger:
                 self.logger.debug(f"Applying const value {new_vals}")
             self.apply_values_single_cell(new_vals)
         else:
-            self.spin_boxes.set_values(cur_vals)
-            if 2 < self.handler.bands_nr < 5:
+            spin_boxes.set_values(cur_vals)
+            if 2 < handler.bands_nr < 5:
                 self.color_picker_connection(connect=False)
-                self.color_btn.setColor(QColor(*self.spin_boxes.get_values()[:4]))
+                self.color_btn.setColor(QColor(*spin_boxes.get_values()[:4]))
                 self.color_picker_connection(connect=True)
 
     def set_values_from_picker(self, c):
         """Set bands spinboxes values after color change in the color picker"""
+        handler = self.handler
+        spin_boxes = self.spin_boxes
+        
+        if handler is None or spin_boxes is None:
+            if self.logger:
+                self.logger.warning("Raster handler or band spin boxes are not available")
+            return
+        
         values = None
-        if self.handler.bands_nr > 2:
+        if handler.bands_nr > 2:
             values = [c.red(), c.green(), c.blue()]
-            if self.handler.bands_nr == 4:
+            if handler.bands_nr == 4:
                 values.append(c.alpha())
         if values:
-            self.spin_boxes.set_values(values)
+            spin_boxes.set_values(values)
 
     def set_nodata(self):
         """Set NoData value(s) for each band of current raster."""
-        if not self.raster:
+        raster = self.raster
+        handler = self.handler
+
+        if raster is None:
             self.uc.bar_warn('Select a raster layer to define/change NoData value!')
             return
-        if self.handler.provider.userNoDataValues(1):
+        if handler is None:
+            if self.logger:
+                self.logger.warning("Raster handler is not available")
+            return
+
+        provider = handler.provider
+
+        if provider.userNoDataValues(1):
             note = '\nNote: there is a user defined NODATA value.\nCheck the raster properties (Transparency).'
         else:
             note = ''
-        dt = self.handler.provider.dataType(1)
-        
+        dt = provider.dataType(1)
+
         # current NODATA value
-        if self.handler.provider.sourceHasNoDataValue(1):
-            cur_nodata = self.handler.provider.sourceNoDataValue(1)
+        if provider.sourceHasNoDataValue(1):
+            cur_nodata = provider.sourceNoDataValue(1)
             if dt < 6:
                 cur_nodata = '{0:d}'.format(int(float(cur_nodata)))
         else:
@@ -643,7 +764,7 @@ class Serval(object):
         
         label = 'Define/change raster NODATA value.\n\n'
         label += 'Raster src_data type: {}.{}'.format(dtypes[dt]['name'], note)
-        nd, ok = QInputDialog.getText(None, "Define NODATA Value", label, QLineEdit.Normal, str(cur_nodata))
+        nd, ok = QInputDialog.getText(None, "Define NODATA Value", label, QLineEdit.EchoMode.Normal, str(cur_nodata))
         if not ok:
             return
         if not is_number(nd):
@@ -653,9 +774,9 @@ class Serval(object):
         
         # set the NODATA value for each band
         res = []
-        for nr in self.handler.bands_range:
-            res.append(self.handler.provider.setNoDataValue(nr, new_nodata))
-            self.handler.provider.sourceHasNoDataValue(nr)
+        for nr in handler.bands_range:
+            res.append(provider.setNoDataValue(nr, new_nodata))
+            provider.sourceHasNoDataValue(nr)
         
         if False in res:
             self.uc.show_warn('Setting new NODATA value failed!')
@@ -663,15 +784,24 @@ class Serval(object):
             self.uc.bar_info('Successful setting new NODATA values!', dur=2)
 
         self.set_active_raster()
-        self.raster.triggerRepaint()
+        if self.raster is not None:
+            self.raster.triggerRepaint()
         
     def check_undo_redo_btns(self):
         """Enable/Disable undo and redo buttons based on availability of undo/redo for current raster."""
         self.undo_btn.setDisabled(True)
         self.redo_btn.setDisabled(True)
-        if self.raster is None or self.raster.id() not in self.changes:
+        
+        raster = self.raster
+        changes_map = self.changes
+        
+        if raster is None:
             return
-        changes = self.changes[self.raster.id()]
+        raster_id = raster.id()
+        changes = changes_map.get(raster_id)
+        if changes is None:
+            return
+        
         if changes.nr_undos() > 0:
             self.undo_btn.setEnabled(True)
         if changes.nr_redos() > 0:
@@ -679,11 +809,15 @@ class Serval(object):
 
     def enable_toolbar_actions(self, enable=True):
         """Enable / disable all toolbar actions but Help (for vectors and unsupported rasters)"""
-        for widget in self.actions + [self.width_unit_cbo, self.line_width_sbox]:
+        actions = self.actions
+        always_on = self.actions_always_on
+        for widget in actions + [self.width_unit_cbo, self.line_width_sbox]:
             widget.setEnabled(enable)
-            if widget in self.actions_always_on:
+            if widget in always_on:
                 widget.setEnabled(True)
-        self.spin_boxes.enable(enable)
+        spin_boxes = self.spin_boxes
+        if spin_boxes is not None:
+            spin_boxes.enable(enable)
 
     @staticmethod
     def check_layer(layer):
@@ -705,53 +839,99 @@ class Serval(object):
             return False
 
     def set_bands_cbo(self):
+        handler = self.handler
+        if handler is None:
+            if self.logger:
+                self.logger.warning("Raster handler is not available")
+            return
         self.bands_cbo.currentIndexChanged.disconnect(self.update_active_bands)
         self.bands_cbo.clear()
-        for band in self.handler.bands_range:
+        for band in handler.bands_range:
             self.bands_cbo.addItem(f"{band}", [band])
-        if self.handler.bands_nr > 1:
+        if handler.bands_nr > 1:
             self.bands_cbo.addItem(self.RGB, [1, 2, 3])
         self.bands_cbo.setCurrentIndex(0)
         self.bands_cbo.currentIndexChanged.connect(self.update_active_bands)
 
     def update_active_bands(self, idx):
+        handler = self.handler
+        spin_boxes = self.spin_boxes
+        if handler is None or spin_boxes is None:
+            if self.logger:
+                self.logger.warning("Raster handler or band spin boxes are not available")
+            return
+        
         bands = self.bands_cbo.currentData()
-        self.handler.active_bands = bands
-        self.spin_boxes.create_spinboxes(bands, self.handler.data_types, self.handler.nodata_values)
+        if bands is None:
+            if self.logger:
+                self.logger.warning("No active bands selected")
+            return
+        handler.active_bands = bands
+        spin_boxes.create_spinboxes(bands, handler.data_types, handler.nodata_values)
         self.color_btn.setEnabled(len(bands) > 1)
         self.exp_dlg_btn.setEnabled(len(bands) == 1)
 
     def set_active_raster(self):
         """Active layer has changed - check if it is a raster layer and prepare it for the plugin"""
-        old_spin_boxes_values = self.spin_boxes.get_values()
+        spin_boxes = self.spin_boxes
+        project = self.project
+        changes_map = self.changes
+
+        if changes_map is None:
+            if self.logger:
+                self.logger.warning("Raster changes map is not available")
+            return
+        
+        old_spin_boxes_values = spin_boxes.get_values() if spin_boxes is not None else []
         self.crs_transform = None
         layer = self.iface.activeLayer()
+
         if self.check_layer(layer):
             self.raster = layer
-            self.crs_transform = None if self.project.crs() == self.raster.crs() else \
-                QgsCoordinateTransform(self.project.crs(), self.raster.crs(), self.project)
-            self.handler = RasterHandler(self.raster, self.uc, self.debug)
-            supported, unsupported_type = self.handler.write_supported()
+            raster = self.raster
+            
+            if raster is None:
+                self.enable_toolbar_actions(enable=False)
+                self.reset_raster()
+                self.check_undo_redo_btns()
+                return
+
+            if project is None:
+                if self.logger:
+                    self.logger.warning("Project instance is not available")
+                self.enable_toolbar_actions(enable=False)
+                self.reset_raster()
+                self.check_undo_redo_btns()
+                return
+            
+            self.crs_transform = (None if project.crs() == raster.crs() else QgsCoordinateTransform(project.crs(), raster.crs(), project)) 
+            handler = RasterHandler(raster, self.uc, self.debug)
+            self.handler = handler            
+            supported, unsupported_type = handler.write_supported()
             if supported:
                 self.enable_toolbar_actions()
-                self.set_bands_cbo()
-                self.spin_boxes.create_spinboxes(self.handler.active_bands,
-                                                 self.handler.data_types, self.handler.nodata_values)
-                if self.handler.bands_nr == len(old_spin_boxes_values):
-                    self.spin_boxes.set_values(old_spin_boxes_values)
-                self.bands_cbo.setEnabled(self.handler.bands_nr > 1)
-                self.color_btn.setEnabled(len(self.handler.active_bands) > 1)
-                self.rbounds = self.raster.extent().toRectF().getCoords()
-                self.handler.raster_changed.connect(self.add_to_undo)
-                if self.raster.id() not in self.changes:
-                    self.changes[self.raster.id()] = RasterChanges(nr_to_keep=self.settings["undo_steps"])
+                self.set_bands_cbo()                
+                spin_boxes = self.spin_boxes
+                if spin_boxes is not None:
+                    spin_boxes.create_spinboxes(handler.active_bands, handler.data_types, handler.nodata_values)
+                    if handler.bands_nr == len(old_spin_boxes_values):
+                        spin_boxes.set_values(old_spin_boxes_values)
+                elif self.logger:
+                    self.logger.warning("Band spin boxes are not available")
+                self.bands_cbo.setEnabled(handler.bands_nr > 1)
+                self.color_btn.setEnabled(len(handler.active_bands) > 1)
+                self.rbounds = raster.extent().toRectF().getCoords()
+                handler.raster_changed.connect(self.add_to_undo)
+
+                raster_id = raster.id()
+                if changes_map.get(raster_id) is None:
+                    changes_map[raster_id] = RasterChanges(nr_to_keep=self.settings["undo_steps"])            
             else:
                 msg = f"The raster has unsupported src_data type: {unsupported_type}"
                 msg += "\nServal can't work with it, sorry..."
                 self.uc.show_warn(msg)
                 self.enable_toolbar_actions(enable=False)
                 self.reset_raster()
-        
         else:
             # unsupported raster
             self.enable_toolbar_actions(enable=False)
@@ -761,29 +941,81 @@ class Serval(object):
 
     def add_to_undo(self, change):
         """Add the old and new blocks to undo stack."""
-        self.changes[self.raster.id()].add_change(change)
-        self.check_undo_redo_btns()
+        raster = self.raster
+        changes_map = self.changes
+        if raster is None or changes_map is None:
+            if self.logger:
+                self.logger.warning("Raster or changes map is not available")
+            return
+        raster_changes = changes_map.get(raster.id())
+        if raster_changes is None:
+            if self.logger:
+                self.logger.warning("No undo stack found for current raster")
+            return
+        raster_changes.add_change(change)
+        self.check_undo_redo_btns()        
         if self.logger:
             self.logger.debug(self.get_undo_redo_values())
 
     def get_undo_redo_values(self):
-        changes = self.changes[self.raster.id()]
+        raster = self.raster
+        changes_map = self.changes
+        
+        if raster is None or changes_map is None:
+            return "nr undos: 0, redos: 0"
+            
+        changes = changes_map.get(raster.id())
+        if changes is None:
+            return "nr undos: 0, redos: 0"
         return f"nr undos: {changes.nr_undos()}, redos: {changes.nr_redos()}"
 
     def undo(self):
-        undo_data = self.changes[self.raster.id()].undo()
-        self.handler.write_block_undo(undo_data)
-        self.raster.triggerRepaint()
+        raster = self.raster
+        handler = self.handler
+        changes_map = self.changes
+
+        if raster is None or handler is None or changes_map is None:
+            if self.logger:
+                self.logger.warning("Raster, handler or changes map is not available")
+            return
+
+        raster_changes = changes_map.get(raster.id())
+        if raster_changes is None:
+            if self.logger:
+                self.logger.warning("No undo stack found for current raster")
+            return
+
+        undo_data = raster_changes.undo()
+        handler.write_block_undo(undo_data)
+        raster.triggerRepaint()
         self.check_undo_redo_btns()
 
     def redo(self):
-        redo_data = self.changes[self.raster.id()].redo()
-        self.handler.write_block_undo(redo_data)
-        self.raster.triggerRepaint()
+        raster = self.raster
+        handler = self.handler
+        changes_map = self.changes
+
+        if raster is None or handler is None or changes_map is None:
+            if self.logger:
+                self.logger.warning("Raster, handler or changes map is not available")
+            return
+
+        raster_changes = changes_map.get(raster.id())
+        if raster_changes is None:
+            if self.logger:
+                self.logger.warning("No redo stack found for current raster")
+            return
+
+        redo_data = raster_changes.redo()
+        handler.write_block_undo(redo_data)
+        raster.triggerRepaint()
         self.check_undo_redo_btns()
 
     def reset_raster(self):
         self.raster = None
+        self.handler = None
+        self.rbounds = None
+        self.crs_transform = None
         self.color_btn.setDisabled(True)
 
     def color_picker_connection(self, connect=True):
@@ -798,76 +1030,201 @@ class Serval(object):
 
     def recreate_spatial_index(self, layer):
         """Check if spatial index exists for the layer and if it is relatively old and eventually recreate it."""
-        ctime = self.spatial_index_time[layer.id()] if layer.id() in self.spatial_index_time else None
+        layer_id = layer.id()
+        ctime = self.spatial_index_time.get(layer_id)
         if ctime is None or datetime.now() - ctime > timedelta(seconds=30):
-            self.spatial_index = QgsSpatialIndex(layer.getFeatures(), None, QgsSpatialIndex.FlagStoreFeatureGeometries)
-            self.spatial_index_time[layer.id()] = datetime.now()
+            self.spatial_index[layer_id] = QgsSpatialIndex(layer.getFeatures(), None, QgsSpatialIndex.FlagStoreFeatureGeometries)
+            self.spatial_index_time[layer_id] = datetime.now()
 
     def get_nearest_feature(self, pt_feat, vlayer_id):
         """Given the point feature, return nearest feature from vlayer."""
-        vlayer = self.project.mapLayer(vlayer_id)
+        project = self.project
+        if project is None:
+            if self.logger:
+                self.logger.warning("Project instance is not available")
+            return None
+
+        vlayer = project.mapLayer(vlayer_id)
+        if vlayer is None:
+            if self.logger:
+                self.logger.warning(f"Vector layer not found: {vlayer_id}")
+            return None
+
         self.recreate_spatial_index(vlayer)
-        ptxy = pt_feat.geometry().asPoint()
-        near_fid = self.spatial_index.nearestNeighbor(ptxy)[0]
+
+        spatial_indexes = self.spatial_index
+        spatial_index = spatial_indexes.get(vlayer.id())
+        if spatial_index is None:
+            if self.logger:
+                self.logger.warning(f"Spatial index is not available for layer '{vlayer.id()}'")
+            return None
+
+        pt_geom = pt_feat.geometry()
+        if pt_geom is None or pt_geom.isEmpty():
+            if self.logger:
+                self.logger.warning("Point feature has no valid geometry")
+            return None        
+        
+        ptxy = pt_geom.asPoint()
+        nearest = spatial_index.nearestNeighbor(ptxy)
+        if not nearest:
+            if self.logger:
+                self.logger.warning("No nearest feature found")
+            return None
+
+        near_fid = nearest[0]
         return vlayer.getFeature(near_fid)
 
     def nearest_feature_attr_value(self, pt_feat, vlayer_id, attr_name):
         """Find nearest feature to pt_feat and return its attr_name attribute value."""
         near_feat = self.get_nearest_feature(pt_feat, vlayer_id)
+        if near_feat is None:
+            if self.logger:
+                self.logger.warning(
+                    f"Nearest feature not found for layer '{vlayer_id}' and attribute '{attr_name}'")
+            return None
         return near_feat[attr_name]
 
     def nearest_pt_on_line_interpolate_z(self, pt_feat, vlayer_id):
         """Find nearest line feature to pt_feat and interpolate z value from vertices."""
         near_feat = self.get_nearest_feature(pt_feat, vlayer_id)
+        if near_feat is None:
+            if self.logger:
+                self.logger.warning(f"Nearest line feature not found for layer '{vlayer_id}'")
+            return None
+
         near_geom = near_feat.geometry()
-        closest_pt_dist = near_geom.lineLocatePoint(pt_feat.geometry())
+        if near_geom is None or near_geom.isEmpty():
+            if self.logger:
+                self.logger.warning(f"Nearest feature has no valid geometry for layer '{vlayer_id}'")
+            return None
+
+        pt_geom = pt_feat.geometry()
+        if pt_geom is None or pt_geom.isEmpty():
+            if self.logger:
+                self.logger.warning("Point feature has no valid geometry")
+            return None
+        closest_pt_dist = near_geom.lineLocatePoint(pt_geom)
         closest_pt = near_geom.interpolate(closest_pt_dist)
-        return closest_pt.get().z()
+        closest_pt_geom = closest_pt.get()
+        if closest_pt_geom is None:
+            if self.logger:
+                self.logger.warning("Interpolated closest point geometry is not available")
+            return None
+
+        return closest_pt_geom.z()
 
     def intersecting_features_attr_average(self, pt_feat, vlayer_id, attr_name, only_center):
         """
         Find all features intersecting current feature (cell center, or raster cell polygon) and calculate average
         value of their attr_name attribute.
         """
-        vlayer = self.project.mapLayer(vlayer_id)
+        project = self.project
+        handler = self.handler
+
+        if project is None or handler is None:
+            if self.logger:
+                self.logger.warning("Project instance or raster handler is not available")
+            return None
+
+        vlayer = project.mapLayer(vlayer_id)
+        if vlayer is None:
+            if self.logger:
+                self.logger.warning(f"Vector layer not found: {vlayer_id}")
+            return None
+
         self.recreate_spatial_index(vlayer)
-        ptxy = pt_feat.geometry().asPoint()
+
+        spatial_indexes = self.spatial_index
+        spatial_index = spatial_indexes.get(vlayer.id())
+        if spatial_index is None:
+            if self.logger:
+                self.logger.warning(f"Spatial index is not available for layer '{vlayer.id()}'")
+            return None
+
+        pt_geom = pt_feat.geometry()
+        if pt_geom is None or pt_geom.isEmpty():
+            if self.logger:
+                self.logger.warning("Point feature has no valid geometry")
+            return None
+        ptxy = pt_geom.asPoint()
         pt_x, pt_y = ptxy.x(), ptxy.y()
         dxy = 0.001
-        half_pix_x = self.handler.pixel_size_x / 2.
-        half_pix_y = self.handler.pixel_size_y / 2.
+        half_pix_x = handler.pixel_size_x / 2.0
+        half_pix_y = handler.pixel_size_y / 2.0
+
         if only_center:
             cell = QgsRectangle(pt_x, pt_y, pt_x + dxy, pt_y + dxy)
         else:
-            cell = QgsRectangle(pt_x - half_pix_x, pt_y - half_pix_y,
-                                pt_x + half_pix_x, pt_y + half_pix_y)
-        inter_fids = self.spatial_index.intersects(cell)
+            cell = QgsRectangle(
+                pt_x - half_pix_x,
+                pt_y - half_pix_y,
+                pt_x + half_pix_x,
+                pt_y + half_pix_y,
+            )
+
+        inter_fids = spatial_index.intersects(cell)
         values = []
+
         for fid in inter_fids:
             feat = vlayer.getFeature(fid)
-            if not feat.geometry().intersects(cell):
+            feat_geom = feat.geometry()
+            if feat_geom is None or not feat_geom.intersects(cell):
                 continue
+
             val = feat[attr_name]
             if not is_number(val):
                 continue
+
             values.append(val)
-        if len(values) == 0:
+
+        if not values:
             return None
+
         return sum(values) / float(len(values))
 
     def interpolate_from_mesh(self, pt_feat, mesh_layer_id, group, dataset, above_existing):
         """Interpolate from mesh."""
-        mesh_layer = self.project.mapLayer(mesh_layer_id)
-        ptxy = pt_feat.geometry().asPoint()
+        project = self.project
+        handler = self.handler
+
+        if project is None or handler is None:
+            if self.logger:
+                self.logger.warning("Project instance or raster handler is not available")
+            return None
+
+        mesh_layer = project.mapLayer(mesh_layer_id)
+        if mesh_layer is None:
+            if self.logger:
+                self.logger.warning(f"Mesh layer not found: {mesh_layer_id}")
+            return None
+
+        pt_geom = pt_feat.geometry()
+        if pt_geom is None or pt_geom.isEmpty():
+            if self.logger:
+                self.logger.warning("Point feature has no valid geometry")
+            return None
+
+        ptxy = pt_geom.asPoint()
         dataset_val = mesh_layer.datasetValue(QgsMeshDatasetIndex(group, dataset), ptxy)
         val = dataset_val.scalar()
+
         if math.isnan(val):
             return val
+
         if above_existing:
-            ident_vals = self.handler.provider.identify(ptxy, QgsRaster.IdentifyFormatValue).results()
-            org_val = list(ident_vals.values())[0]
-            if org_val == self.handler.nodata_values[0]:
+            ident_vals = handler.provider.identify(ptxy, QgsRaster.IdentifyFormatValue).results()
+            if not ident_vals:
                 return val
+
+            nodata_values = handler.nodata_values
+            if not nodata_values:
+                return val
+
+            org_val = list(ident_vals.values())[0]
+            if org_val == nodata_values[0]:
+                return val
+
             return max(org_val, val)
-        else:
-            return val
+
+        return val


### PR DESCRIPTION
Summary of Improvements

Improved compatibility and robustness between QGIS 3 / QGIS 4 and Qt5 / Qt6 with various code adjustments and updated metadata up to qgisMaximumVersion=4.99.

Defensive refactoring of the core plugin (serval.py) with systematic checks for optional objects (raster, handler, spin_boxes, project, undo/redo cache), reducing potential crashes and Pylance static warnings.

Cleaner raster state management, with consistent resetting of handlers, bounds, and CRS transformations when the active layer changes or is not supported.

Consolidated undo/redo, with safer raster changemap management and correct cleanup in unload(). The logic of the RasterChange / RasterChanges classes remains simple and uncluttered.

Correct and consistent spatial index caching per layer, using dedicated structures for layer_id -> creation time and layer_id -> QgsSpatialIndex, avoiding inconsistencies when working with multiple layers.

More robust raster selection tools, with improved handling of temporary/invalid geometry during interactive drawing and cleaner map tool resets.

Improved multiband handling, with BandBoxes more tolerant of missing/NoData values ​​and spinboxes recreated more safely when bands or raster types change.

Improved NoData handling, both UI and handler-side, including more robust handling of source and user-defined NoData values.

Greater stability of expressive functions and geometric operations (nearest features, averaging attributes on intersecting features, interpolation from lines and meshes), with additional controls for layers, geometries, and intermediate results.

Improved the resilience of the raster editing workflow in RasterHandler, with checks on blocks, temporary layers, selected cells, expressed values, and raster types before writing.

Update metadata: bump version to 3.33.0 and refresh changelog

This pull request updates the plugin metadata to version 3.33.0 and refreshes the changelog accordingly.

Changes included:
- Updated `version` field to 3.33.0
- Updated Qt5 / Qt6 compatibility notes
- Added and reorganized changelog entries for recent releases
- Ensured metadata formatting and indentation are consistent